### PR TITLE
Fix license file

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,5 +1,4 @@
-he MIT License (MIT)
-Copyright (c) 2017 Lockey SPRL
+Copyright (c) 2018 Isabel NV
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
 


### PR DESCRIPTION
There is a typo in the license file that prevents github from identifying the license type. Also, the line with the typo is not necessary.