### PR TITLE
Fix: Signature generation with query params

### DIFF
--- a/lib/ibanity/http_signature.rb
+++ b/lib/ibanity/http_signature.rb
@@ -35,7 +35,7 @@ module Ibanity
     end
 
     def request_target
-      @uri.query = URI.encode_www_form(URI.decode_www_form(@uri.query.to_s).concat(@query_params.to_a)) if @query_params&.keys&.any?
+      @uri.query = RestClient::Utils.encode_query_string(@query_params) if @query_params&.keys&.any?
       "#{@method} #{@uri.request_uri}"
     end
 


### PR DESCRIPTION
The implementation for encoding the query params to a URI in the `HttpSignature`
class, was not correct. For nested query params, `RestClient` works as
follows:
https://github.com/rest-client/rest-client#query-parameters

The `HttpSignature` class should use the same formatting, if not you get
an invalid signature error.