### PR TITLE
File streaming

### DIFF
--- a/lib/ibanity/client.rb
+++ b/lib/ibanity/client.rb
@@ -106,6 +106,8 @@ module Ibanity
       JSON.parse(raw_response)
     rescue JSON::ParserError => e
       return raw_response.body
+    ensure
+      payload.close if payload.is_a?(File)
     end
 
     def build_headers(customer_access_token: nil, idempotency_key: nil, extra_headers: nil, json:)

--- a/lib/ibanity/client.rb
+++ b/lib/ibanity/client.rb
@@ -3,7 +3,22 @@ module Ibanity
 
     attr_reader :base_uri, :signature_certificate, :signature_key, :isabel_connect_client_id, :isabel_connect_client_secret, :ponto_connect_client_id, :ponto_connect_client_secret
 
-    def initialize(certificate:, key:, key_passphrase:, signature_certificate: nil, signature_certificate_id: nil, signature_key: nil, signature_key_passphrase: nil, api_scheme: "https", api_host: "api.ibanity.com", api_port: "443", ssl_ca_file: nil, isabel_connect_client_id: "valid_client_id", isabel_connect_client_secret: "valid_client_secret", ponto_connect_client_id: nil, ponto_connect_client_secret: nil)
+    def initialize(
+        certificate:,
+        key:,
+        key_passphrase:,
+        signature_certificate: nil,
+        signature_certificate_id: nil,
+        signature_key: nil,
+        signature_key_passphrase: nil,
+        api_scheme: "https",
+        api_host: "api.ibanity.com",
+        api_port: "443",
+        ssl_ca_file: nil,
+        isabel_connect_client_id: "valid_client_id",
+        isabel_connect_client_secret: "valid_client_secret",
+        ponto_connect_client_id: nil,
+        ponto_connect_client_secret: nil)
       @isabel_connect_client_id     = isabel_connect_client_id
       @isabel_connect_client_secret = isabel_connect_client_secret
       @ponto_connect_client_id      = ponto_connect_client_id

--- a/lib/ibanity/client.rb
+++ b/lib/ibanity/client.rb
@@ -40,12 +40,12 @@ module Ibanity
     end
 
     def post(uri:, payload:, query_params: {}, customer_access_token: nil, idempotency_key: nil, json: true, headers: nil)
-      headers = build_headers(customer_access_token: customer_access_token, idempotency_key: idempotency_key, extra_headers: headers, json: json)
+      headers = build_headers(customer_access_token: customer_access_token, idempotency_key: idempotency_key, extra_headers: headers, json: json, payload: payload)
       execute(method: :post, uri: uri, headers: headers, query_params: query_params, payload: payload, json: json)
     end
 
     def patch(uri:, payload:, query_params: {}, customer_access_token: nil, idempotency_key: nil, json: true)
-      headers = build_headers(customer_access_token: customer_access_token, idempotency_key: idempotency_key, json: json)
+      headers = build_headers(customer_access_token: customer_access_token, idempotency_key: idempotency_key, json: json, payload: payload)
       execute(method: :patch, uri: uri, headers: headers, query_params: query_params, payload: payload, json: json)
     end
 
@@ -110,10 +110,11 @@ module Ibanity
       payload.close if payload.is_a?(File)
     end
 
-    def build_headers(customer_access_token: nil, idempotency_key: nil, extra_headers: nil, json:)
+    def build_headers(customer_access_token: nil, idempotency_key: nil, extra_headers: nil, json:, payload: nil)
       headers = {
         accept: :json,
       }
+      headers["Transfer-Encoding"]       = "chunked" if payload.is_a?(Pathname)
       headers[:content_type]             = :json if json
       headers["Authorization"]           = "Bearer #{customer_access_token}" unless customer_access_token.nil?
       headers["Ibanity-Idempotency-Key"] = idempotency_key unless idempotency_key.nil?

--- a/lib/ibanity/client.rb
+++ b/lib/ibanity/client.rb
@@ -93,8 +93,7 @@ module Ibanity
         ssl_client_key:  @key,
         ssl_ca_file:     @ssl_ca_file
       }
-      puts "Payload size: #{payload.size}" if payload
-      puts "Payload class: #{payload.class}"
+
       raw_response = RestClient::Request.execute(query) do |response, request, result, &block|
         if response.code >= 400
           ibanity_request_id = response.headers[:ibanity_request_id]

--- a/lib/ibanity/client.rb
+++ b/lib/ibanity/client.rb
@@ -61,6 +61,15 @@ module Ibanity
     private
 
     def execute(method:, uri:, headers:, query_params: {}, payload: nil, json:)
+      case payload
+      when NilClass
+        payload = ''
+      when String
+        payload = json ? payload.to_json : payload
+      when Pathname
+        payload = File.open(payload, 'rb')
+      end
+
       if @signature_certificate
         signature = Ibanity::HttpSignature.new(
           certificate:    @signature_certificate,
@@ -70,18 +79,9 @@ module Ibanity
           uri:            uri,
           query_params:   query_params,
           headers:        headers,
-          payload:        payload && json ? payload.to_json : payload
+          payload:        payload
         )
         headers.merge!(signature.signature_headers)
-      end
-
-      case payload
-        when NilClass
-          payload = ''
-        when String
-          payload = json ? payload.to_json : payload
-        when Pathname
-          payload = File.open(payload, 'rb')
       end
 
       query = {

--- a/lib/ibanity/http_signature.rb
+++ b/lib/ibanity/http_signature.rb
@@ -40,7 +40,7 @@ module Ibanity
           digest = compute_digest_string("")
         when String
           digest = compute_digest_string(@payload)
-        when Pathname
+        when File
           digest = compute_digest_file(@payload)
       end
       base64 = Base64.urlsafe_encode64(digest.digest)

--- a/lib/ibanity/http_signature.rb
+++ b/lib/ibanity/http_signature.rb
@@ -1,4 +1,5 @@
 require "base64"
+require "pathname"
 
 module Ibanity
   class HttpSignature
@@ -29,14 +30,36 @@ module Ibanity
       }
     end
 
-    private
-
     def payload_digest
-      digest         = OpenSSL::Digest::SHA512.new
-      string_payload = @payload.nil? ? "" : @payload
-      digest.update(string_payload)
+      @payload_digest ||= compute_digest
+    end
+
+    def compute_digest
+      case @payload
+        when NilClass
+          digest = compute_digest_string("")
+        when String
+          digest = compute_digest_string(@payload)
+        when Pathname
+          digest = compute_digest_file(@payload)
+      end
       base64 = Base64.urlsafe_encode64(digest.digest)
       "SHA-512=#{base64}"
+    end
+
+    def compute_digest_string(str)
+      digest = OpenSSL::Digest::SHA512.new
+      digest.update(str)
+    end
+
+    def compute_digest_file(pathname)
+      digest = OpenSSL::Digest::SHA512.new
+      File.open(pathname, 'rb') do |f|
+        while buffer = f.read(256_000)
+          digest << buffer
+        end
+      end
+      digest
     end
 
     def headers_to_sign


### PR DESCRIPTION
* Allow passing a `Pathname` as payload, reducing the memory footprint when payload is large
* Set `Transfer-Encoding` to true when payload is a `Pathname`