### PR TITLE
Skip nil relationships in BaseResource#setup_relationships

### DIFF
--- a/lib/ibanity/api/base_resource.rb
+++ b/lib/ibanity/api/base_resource.rb
@@ -99,6 +99,8 @@ module Ibanity
 
     def setup_relationships(relationships, customer_access_token = nil)
       relationships.each do |key, relationship|
+        next if relationship.nil?
+
         url = relationship.dig("links", "related")
         id = relationship.dig("data", "id")
 

--- a/spec/lib/ibanity/base_resource_spec.rb
+++ b/spec/lib/ibanity/base_resource_spec.rb
@@ -27,6 +27,15 @@ RSpec.describe Ibanity::BaseResource do
       end
     end
 
+    context "when a relationship value is nil" do
+      it "skips the nil relationship and processes the rest" do
+        car = Ibanity::Xs2a::Car.new(Fixture.load_json("relationships/nil_relationship.json"))
+
+        expect(car).to respond_to(:maker)
+        expect(car).not_to respond_to(:previous_owner)
+      end
+    end
+
     context "when there's no 'links/related' element" do
       let(:car) { Ibanity::Xs2a::Car.new(Fixture.load_json("relationships/no_links_related.json")) }
 

--- a/spec/support/fixtures/json/relationships/nil_relationship.json
+++ b/spec/support/fixtures/json/relationships/nil_relationship.json
@@ -1,0 +1,19 @@
+{
+  "attributes": {
+    "color": "blue"
+  },
+  "id": "62ebd4687e",
+  "relationships": {
+    "maker": {
+      "data": {
+        "id": "c4ebf0f7",
+        "type": "manufacturer"
+      },
+      "links": {
+        "related": "https://www.cardb.com/manufacturers/c4ebf0f7"
+      }
+    },
+    "previousOwner": null
+  },
+  "type": "car"
+}


### PR DESCRIPTION
## Problem

When the PontoConnect API returns `null` for a relationship value in a JSON:API response, `BaseResource#setup_relationships` crashes with `NoMethodError: undefined method 'dig' for nil`.

Example API response that triggers the error:

```json
{
  "type": "payment",
  "relationships": {
    "paymentVop": null
  }
}
```

The `null` value is valid in JSON:API (represents an empty to-one relationship), but the gem doesn't handle it:

```ruby
relationships.each do |key, relationship|
  url = relationship.dig("links", "related")  # NoMethodError when relationship is nil
```

## Fix

Add `next if relationship.nil?` to skip null relationship values.